### PR TITLE
Added arch amd64 & ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch:
+ - amd64
+ - ppc64le
+ 
 language: c
 before_script: ./autogen.sh && ./configure --enable-developer-warnings --enable-werror
 script: make check


### PR DESCRIPTION
Hi
Added power support for the travis.yml file with ppc64le. 
This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.
For more info please contact @gerrith3